### PR TITLE
Add Ian and Matt's Hunchpig emails

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,8 @@
 
 # Site settings
 title: Hunchpig
-email: ian+hunchpig@iancanderson.com
+ian_email: ian@hunchpig.audio
+matt_email: matt@hunchpig.audio
 description: > # this means to ignore newlines until "baseurl:"
   In this podcast, Ian and Matt ramble on about growing up on
   different sides of the pond, developing software for the web, and figuring out
@@ -34,7 +35,7 @@ podcastTitle: Hunchpig
 
 # About You. For iTunes admin. This information is not displayed on the iTunes Store.
 podcastOwner: Ian Anderson
-podcastEmail: ian+hunchpig@iancanderson.com
+podcastEmail: ian@hunchpig.audio
 
 # See https://www.apple.com/itunes/podcasts/specs.html near the bottom for valid categories
 category: Society &amp; Culture

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,8 +7,8 @@
     <div class="footer-col-wrapper">
       <div class="footer-col footer-col-1">
         <ul class="contact-list">
-          <li>{{ site.title }}</li>
-          <li><a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
+          <li><a href="mailto:{{ site.ian_email }}">Email Ian</a></li>
+          <li><a href="mailto:{{ site.matt_email }}">Email Matt</a></li>
         </ul>
       </div>
 


### PR DESCRIPTION
Why:

We would like for listeners to be able to email either of Hunchpig's
charismatic hosts secure in the knowledge of whom they are trading
correspondences.

This PR:

Adds both emails to the site footer and changes the text to be
friendlier then a bare email.

<img width="707" alt="screen shot 2017-03-25 at 10 29 06 am" src="https://cloud.githubusercontent.com/assets/759721/24323043/19009570-1146-11e7-97e4-d6c0d5e62558.png">